### PR TITLE
Implement plus profile injection

### DIFF
--- a/api/mercadopago.js
+++ b/api/mercadopago.js
@@ -86,11 +86,12 @@ app.post('/api/webhook', async (req, res) => {
     if (payment.status === 'approved') {
       await admin
         .firestore()
-        .collection('users')
+        .collection('usuarios')
         .doc(uid)
         .set(
           {
             isPlus:     true,
+            plano:      'plus',
             upgradedAt: admin.firestore.FieldValue.serverTimestamp(),
           },
           { merge: true }

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -20,12 +20,16 @@ export default async function handler(req, res) {
     const uid = data.external_reference;
     await admin
       .firestore()
-      .collection('users')
+      .collection('usuarios')
       .doc(uid)
-      .set({
-        isPlus:     true,
-        upgradedAt: admin.firestore.FieldValue.serverTimestamp()
-      }, { merge: true });
+      .set(
+        {
+          isPlus:     true,
+          plano:      'plus',
+          upgradedAt: admin.firestore.FieldValue.serverTimestamp(),
+        },
+        { merge: true }
+      );
   }
 
   return res.sendStatus(200);


### PR DESCRIPTION
## Summary
- store Plus upgrade info under `usuarios` collection
- set both `plano: 'plus'` and `isPlus` when Mercado Pago webhook triggers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687841d1f420832398be01c4ae879c51