### PR TITLE
Add landing page route for root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
   ],
   "routes": [
     { "src": "/api/(.*)",     "dest": "api/$1.js" },
+    { "src": "/",             "dest": "/public/landing.html" },
     { "src": "/(.*)",         "dest": "/public/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- modify `vercel.json` routing so `/` serves `public/landing.html`

## Testing
- `node node_modules/serve/build/main.js public -l 5000` with a temporary `serve.json`
- `curl -I http://localhost:5000/`
- `curl -L -s http://localhost:5000/login.html`
- `curl -L -s http://localhost:5000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68784fbd67a08323afaf72108f2cee9c