### PR TITLE
Add placeholder tests for subscription logic

### DIFF
--- a/mock-loader.mjs
+++ b/mock-loader.mjs
@@ -1,0 +1,14 @@
+export async function load(url, context, defaultLoad) {
+  if (url.includes('node_modules/firebase-admin')) {
+    if (url.includes('/app/')) {
+      return { shortCircuit: true, format: 'module', source: `export const initializeApp=()=>{};export const cert=()=>{};export const getApps=()=>[];` };
+    }
+    if (url.includes('/auth')) {
+      return { shortCircuit: true, format: 'module', source: `export const getAuth=()=>({verifyIdToken: async()=>({uid:'testuid'})});` };
+    }
+    if (url.includes('/firestore')) {
+      return { shortCircuit: true, format: 'module', source: `export const getFirestore=()=>({collection:()=>({doc:(id)=>({_id:id,set:async(d)=>{(global.__sets||(global.__sets={}))[id]=d;},get:async()=>({exists:true,data:()=>global.__data&&global.__data[id]||{}})})})});` };
+    }
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vercel dev",
-    "start": "node api/chat.js"
+    "start": "node api/chat.js",
+    "test": "node --loader ./mock-loader.mjs tests/run.js"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/tests/cancel-subscription.test.js
+++ b/tests/cancel-subscription.test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+export default async function() {
+  process.env.FIREBASE_SERVICE_ACCOUNT = JSON.stringify({project_id:'x',client_email:'x',private_key:'x'});
+  global.__sets = {};
+  const { default: handler } = await import('../api/user/cancel-subscription.js');
+  const req = { method: 'POST', headers: { authorization: 'Bearer token' } };
+  const res = { statusCode: 0, body: null, status(code) { this.statusCode = code; return { json: obj => { this.body = obj; }, end:()=>{} }; } };
+  await handler(req, res);
+  assert.strictEqual(res.statusCode, 200);
+  assert.deepStrictEqual(res.body, { success: true });
+  assert.strictEqual(global.__sets.testuid.status, 'cancelled');
+  assert.ok('expiresAt' in global.__sets.testuid);
+}

--- a/tests/management-page.test.js
+++ b/tests/management-page.test.js
@@ -1,0 +1,6 @@
+import assert from 'assert';
+import fs from 'fs';
+export default async function() {
+  const html = fs.readFileSync('./public/gerenciar.html', 'utf8');
+  assert.ok(html.includes('FREE MEMBER'), 'page should show FREE MEMBER');
+}

--- a/tests/run.js
+++ b/tests/run.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+let passed = 0, failed = 0;
+for (const file of fs.readdirSync('./tests')) {
+  if (file.endsWith('.test.js')) {
+    try {
+      const mod = await import(`./${file}`);
+      await mod.default();
+      console.log('✓', file);
+      passed++;
+    } catch (err) {
+      console.error('✗', file, err.message);
+      failed++;
+    }
+  }
+}
+console.log(`${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/tests/scheduled-function.test.js
+++ b/tests/scheduled-function.test.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+export default async function() {
+  const mod = await import('../functions/index.js');
+  assert.ok(mod.expireSubscriptions, 'expireSubscriptions function exists');
+  // Setup mock data
+  global.__data = {user1: {plano: 'plus', expiresAt: Date.now() - 1000}};
+  await mod.expireSubscriptions();
+  assert.strictEqual(global.__data.user1.plano, 'gratis');
+}


### PR DESCRIPTION
## Summary
- add mock-loader to stub firebase-admin imports
- add minimal test runner and subscription tests
- include npm script to run tests

## Testing
- `npm test` *(fails: `cancel-subscription.test.js` and `scheduled-function.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68800c6b89488323ae4543a83b5608e1