### PR TITLE
Implement secure account removal

### DIFF
--- a/public/gerenciar.html
+++ b/public/gerenciar.html
@@ -1400,7 +1400,7 @@
                         Esta ação é irreversível. Todos os seus dados serão permanentemente deletados.
                     </p>
                 </div>
-                <button class="btn btn-danger btn-full" onclick="excluirConta()">
+                <button class="btn btn-danger btn-full" onclick="deleteAccount()">
                     Excluir Conta Permanentemente
                 </button>
             </div>
@@ -2011,13 +2011,15 @@
 
         // Excluir conta
         function deleteAccount() {
-            // Primeiro, simular envio de código de verificação
             showNotification('📧 Enviando código de verificação para seu e-mail...', 'info');
-            
-            setTimeout(() => {
-                openModal('deleteModal');
-                showNotification('✅ Código enviado! Verifique seu e-mail.', 'success');
-            }, 1500);
+            apiRequest('/api/user/send-delete-code', { method: 'POST' })
+                .then(() => {
+                    openModal('deleteModal');
+                    showNotification('✅ Código enviado! Verifique seu e-mail.', 'success');
+                })
+                .catch(() => {
+                    showNotification('❌ Erro ao enviar código de verificação', 'error');
+                });
         }
 
         // Upgrade da conta
@@ -2248,13 +2250,16 @@
                 apiRequest('/api/user/account', { method: 'DELETE', body: { password, code } })
                     .then(() => {
                         showNotification('⚠️ Conta excluída permanentemente!', 'error');
-                        setTimeout(() => { window.location.href = '/login?account_deleted=true'; }, 2000);
+                        firebase.auth().signOut().finally(() => {
+                            localStorage.clear();
+                            setTimeout(() => { window.location.href = '/login?account_deleted=true'; }, 1000);
+                        });
                     })
                     .catch(() => {
                         showNotification('❌ Erro ao excluir conta', 'error');
                     });
             } else {
-                alert('⚠️ Preencha todos os campos corretamente');
+                showNotification('⚠️ Preencha todos os campos corretamente', 'warning');
             }
         }
 
@@ -2753,11 +2758,7 @@
         }
 
         function excluirConta() {
-            if (confirm('Tem certeza que deseja excluir sua conta permanentemente?')) {
-                localStorage.clear();
-                alert('Conta excluída.');
-                window.location.href = 'index.html';
-            }
+            deleteAccount();
         }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- wire up the real delete button to the account removal flow
- send verification code before confirming deletion
- sign out and clear data after deleting
- verify password and clean Firestore/Storage on account removal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688033bdfeb88323830ea1f4ea757d03