### PR TITLE
Configure CORS for chat API

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -263,6 +263,12 @@ export default async function handler(req, res) {
     hasBody: !!req.body
   });
 
+  // Configura cabecalhos de CORS
+  const allowedOrigin = 'https://prod-ai-teste.vercel.app';
+  res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
   // Tratamento de CORS
   if (req.method === 'OPTIONS') {
     return res.status(200).end();


### PR DESCRIPTION
## Summary
- allow frontend domain `https://prod-ai-teste.vercel.app` to access `/api/chat`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68818fe42f0083238f04d13f02836045