### PR TITLE
Enable CORS for chat API

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -264,6 +264,10 @@ export default async function handler(req, res) {
   });
 
   // Tratamento de CORS
+  const allowedOrigin = 'https://prod-ai-teste.vercel.app';
+  res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   if (req.method === 'OPTIONS') {
     return res.status(200).end();
   }


### PR DESCRIPTION
## Summary
- allow only `https://prod-ai-teste.vercel.app` to call `/api/chat`
- handle preflight OPTIONS requests with proper headers

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_68819319ff708323ae13ebaaeceee34f