### PR TITLE
fix cors for vercel preview domains

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -9,7 +9,7 @@ const corsMiddleware = cors({
     const fixedOrigin = 'https://prod-ai-teste.vercel.app';
     const vercelPreviewRegex = /^https:\/\/prod-ai-teste-[a-z0-9\-]+\.vercel\.app$/;
 
-    if (!origin || origin === fixedOrigin || vercelPreviewRegex.test(origin)) {
+    if (!origin || origin.includes(fixedOrigin) || vercelPreviewRegex.test(origin)) {
       callback(null, true);
     } else {
       callback(new Error('Not allowed by CORS: ' + origin));

--- a/api/mercadopago.js
+++ b/api/mercadopago.js
@@ -10,7 +10,7 @@ app.use(cors({
     const fixedOrigin = 'https://prod-ai-teste.vercel.app';
     const vercelPreviewRegex = /^https:\/\/prod-ai-teste-[a-z0-9\-]+\.vercel\.app$/;
 
-    if (!origin || origin === fixedOrigin || vercelPreviewRegex.test(origin)) {
+    if (!origin || origin.includes(fixedOrigin) || vercelPreviewRegex.test(origin)) {
       callback(null, true);
     } else {
       callback(new Error('Not allowed by CORS: ' + origin));


### PR DESCRIPTION
## Summary
- allow dynamic vercel preview domains using `origin.includes` and regex

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68819db8b9c88323b5af09dd447161bf